### PR TITLE
fix: disable global history, add health checks, passthrough cache config

### DIFF
--- a/src/dspy_cli/server/auth.py
+++ b/src/dspy_cli/server/auth.py
@@ -27,7 +27,7 @@ ENV_API_TOKEN = "DSPY_API_KEY"
 ENV_AUTH_ENABLED = "DSPY_CLI_AUTH_ENABLED"
 
 # Paths that don't require authentication (defaults)
-DEFAULT_OPEN_PATHS = {"/login", "/health", "/favicon.ico"}
+DEFAULT_OPEN_PATHS = {"/login", "/health", "/health/live", "/health/ready", "/favicon.ico"}
 
 
 def get_api_token() -> str | None:


### PR DESCRIPTION
**Split from #38** (1/5)

### Changes
- **Disable dspy.settings global history** -- it's an unprotected plain list that races under concurrent requests. Inference logs capture everything we need.
- **Add /health/live and /health/ready endpoints** -- standard container health probes. Ready returns 503 until all LMs are initialized.
- **Passthrough cache config** -- the `cache` option in dspy.config.yaml was silently ignored when creating LM instances.

### Files changed
- `src/dspy_cli/server/app.py` (26 insertions, 5 deletions)

### Testing
All 123 existing tests pass.