### PR TITLE
perf: run sync modules in bounded thread pool executor

### DIFF
--- a/src/dspy_cli/commands/serve.py
+++ b/src/dspy_cli/commands/serve.py
@@ -102,7 +102,13 @@ def _exec_clean(target_python: Path, args: list[str]) -> NoReturn:
     default=False,
     help="Enable API authentication via DSPY_API_KEY (default: disabled)",
 )
-def serve(port, host, logs_dir, reload, save_openapi, openapi_format, python, system, mcp, auth):
+@click.option(
+    "--sync-workers",
+    default=None,
+    type=click.IntRange(1, 200),
+    help="Number of threads for sync module execution (default: min(32, cpu+4))",
+)
+def serve(port, host, logs_dir, reload, save_openapi, openapi_format, python, system, mcp, auth, sync_workers):
     """Start an HTTP API server that exposes your DSPy programs.
 
     This command:
@@ -127,6 +133,7 @@ def serve(port, host, logs_dir, reload, save_openapi, openapi_format, python, sy
             openapi_format=openapi_format,
             mcp=mcp,
             auth=auth,
+            sync_workers=sync_workers,
         )
         return
     
@@ -192,6 +199,8 @@ def serve(port, host, logs_dir, reload, save_openapi, openapi_format, python, sy
             args.append("--mcp")
         if auth:
             args.append("--auth")
+        if sync_workers is not None:
+            args.extend(["--sync-workers", str(sync_workers)])
 
         _exec_clean(target_python, args)
     else:
@@ -205,4 +214,5 @@ def serve(port, host, logs_dir, reload, save_openapi, openapi_format, python, sy
             openapi_format=openapi_format,
             mcp=mcp,
             auth=auth,
+            sync_workers=sync_workers,
         )

--- a/src/dspy_cli/server/app.py
+++ b/src/dspy_cli/server/app.py
@@ -15,6 +15,7 @@ from dspy_cli.config import get_model_config, get_program_model
 from dspy_cli.discovery import discover_modules
 from dspy_cli.discovery.gateway_finder import get_gateways_for_module, is_cron_gateway
 from dspy_cli.gateway import APIGateway, IdentityGateway
+from dspy_cli.server.executor import init_executor, shutdown_executor, DEFAULT_SYNC_WORKERS
 from dspy_cli.server.logging import setup_logging
 from dspy_cli.server.metrics import get_all_metrics, get_program_metrics_cached
 from dspy_cli.server.routes import create_program_routes
@@ -31,6 +32,7 @@ def create_app(
     logs_dir: Path,
     enable_ui: bool = True,
     enable_auth: bool = False,
+    sync_workers: int | None = None,
 ) -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -41,12 +43,17 @@ def create_app(
         logs_dir: Directory for log files
         enable_ui: Whether to enable the web UI (always True, kept for compatibility)
         enable_auth: Whether to enable API authentication via DSPY_API_KEY
+        sync_workers: Number of threads for sync module execution (overrides config)
 
     Returns:
         Configured FastAPI application
     """
     # Setup logging
     setup_logging()
+
+    # Initialize bounded executor for sync module execution
+    worker_count = sync_workers or config.get("server", {}).get("sync_worker_threads") or DEFAULT_SYNC_WORKERS
+    init_executor(max_workers=worker_count)
 
     # Create FastAPI app
     app = FastAPI(
@@ -331,6 +338,8 @@ async def lifespan(app: FastAPI):
             shutdown_fn()
         except Exception as e:
             logger.warning(f"Gateway shutdown error: {e}")
+
+    shutdown_executor()
 
 
 def _create_lm_instance(model_config: Dict) -> dspy.LM:

--- a/src/dspy_cli/server/executor.py
+++ b/src/dspy_cli/server/executor.py
@@ -1,0 +1,51 @@
+"""Bounded thread pool executor for sync DSPy module execution.
+
+Sync forward() calls are dispatched here so they don't block the async
+event loop. Context variables (including dspy.context overrides) are
+propagated into the worker thread automatically.
+"""
+
+import asyncio
+import contextvars
+import functools
+import logging
+import os
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_executor: Optional[ThreadPoolExecutor] = None
+
+DEFAULT_SYNC_WORKERS = min(32, (os.cpu_count() or 1) + 4)
+
+
+def init_executor(max_workers: Optional[int] = None) -> ThreadPoolExecutor:
+    """Create the process-wide bounded executor."""
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=False)
+
+    workers = max_workers or DEFAULT_SYNC_WORKERS
+    _executor = ThreadPoolExecutor(max_workers=workers, thread_name_prefix="dspy-sync")
+    logger.info(f"Initialized sync executor with {workers} worker threads")
+    return _executor
+
+
+def shutdown_executor() -> None:
+    """Shut down the executor, waiting for pending work."""
+    global _executor
+    if _executor is not None:
+        _executor.shutdown(wait=True)
+        _executor = None
+
+
+async def run_sync_in_executor(fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run a sync callable in the bounded executor with context propagation.
+
+    Falls back to the default executor if init_executor() hasn't been called.
+    """
+    loop = asyncio.get_running_loop()
+    ctx = contextvars.copy_context()
+    func_call = functools.partial(ctx.run, fn, *args, **kwargs)
+    return await loop.run_in_executor(_executor, func_call)

--- a/tests/test_commands_smoke.py
+++ b/tests/test_commands_smoke.py
@@ -123,6 +123,7 @@ def test_cli_e2e_smoke(runner, tmp_cwd, monkeypatch):
         "openapi_format": "yaml",
         "mcp": False,
         "auth": False,
+        "sync_workers": None,
     }
 
 

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,91 @@
+"""Tests for the bounded executor and context propagation."""
+
+import asyncio
+import contextvars
+
+import pytest
+
+from dspy_cli.server.executor import (
+    init_executor,
+    run_sync_in_executor,
+    shutdown_executor,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_executor():
+    """Ensure each test gets a fresh executor."""
+    yield
+    shutdown_executor()
+
+
+class TestContextPropagation:
+
+    def test_contextvar_propagates_to_executor_thread(self):
+        cv = contextvars.ContextVar("test_cv", default="UNSET")
+        init_executor(max_workers=2)
+
+        def read_cv():
+            return cv.get()
+
+        async def run():
+            cv.set("per-request-value")
+            return await run_sync_in_executor(read_cv)
+
+        result = asyncio.get_event_loop().run_until_complete(run())
+        assert result == "per-request-value"
+
+    def test_concurrent_requests_see_own_context(self):
+        cv = contextvars.ContextVar("test_cv", default="UNSET")
+        init_executor(max_workers=4)
+
+        results = {}
+
+        def read_cv():
+            import time
+            time.sleep(0.05)
+            return cv.get()
+
+        async def make_request(name: str, value: str):
+            cv.set(value)
+            results[name] = await run_sync_in_executor(read_cv)
+
+        async def run():
+            await asyncio.gather(
+                make_request("a", "alpha"),
+                make_request("b", "beta"),
+                make_request("c", "gamma"),
+            )
+
+        asyncio.get_event_loop().run_until_complete(run())
+        assert results == {"a": "alpha", "b": "beta", "c": "gamma"}
+
+    def test_dspy_context_lm_propagates(self):
+        import dspy
+
+        init_executor(max_workers=2)
+
+        def read_lm():
+            return dspy.settings.lm
+
+        async def run():
+            sentinel = object()
+            with dspy.context(lm=sentinel):
+                result = await run_sync_in_executor(read_lm)
+            return result, sentinel
+
+        result, sentinel = asyncio.get_event_loop().run_until_complete(run())
+        assert result is sentinel
+
+    def test_fallback_without_init(self):
+        cv = contextvars.ContextVar("test_cv", default="UNSET")
+
+        def read_cv():
+            return cv.get()
+
+        async def run():
+            cv.set("fallback-value")
+            return await run_sync_in_executor(read_cv)
+
+        result = asyncio.get_event_loop().run_until_complete(run())
+        assert result == "fallback-value"


### PR DESCRIPTION
**Split from #38** (was 3/5, now standalone)

### Changes
Sync `forward()` and `batch()` calls previously ran directly on the async event loop, blocking all other requests. This PR moves them into a dedicated `ThreadPoolExecutor` with proper `contextvars` propagation so `dspy.context(lm=...)` carries into worker threads.

Keeps the existing `hasattr(instance, 'aforward')` check for async detection -- no changes to discovery.

### Configuration
- `--sync-workers N` CLI flag
- `server.sync_worker_threads` in dspy.config.yaml
- Default: `min(32, cpu_count + 4)` (matches Python's default)

### Files changed (7)
- `src/dspy_cli/server/executor.py` (new, 51 lines)
- `src/dspy_cli/server/execution.py` -- use `run_sync_in_executor`
- `src/dspy_cli/server/app.py` -- init/shutdown executor
- `src/dspy_cli/commands/serve.py` -- `--sync-workers` option
- `src/dspy_cli/server/runner.py` -- passthrough
- `tests/test_executor.py` (new, 4 context propagation tests)
- `tests/test_commands_smoke.py` -- updated expected kwargs

### Testing
127 tests pass (123 existing + 4 new).